### PR TITLE
Add `expect.anything()` mock function example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -320,6 +320,8 @@ test('call the callback', () => {
   fn(callback)
   expect(callback).toBeCalled()
   expect(callback.mock.calls[0][1].baz).toBe('pizza') // Second argument of the first call
+  // Match the first and the last arguments but ignore the second argument
+  expect(callback).toHaveBeenLastCalledWith('meal', expect.anything(), 'margarita');
 })
 ```
 


### PR DESCRIPTION
I found this snippet quite helpful when I wanted to check all but one parameter without taking the hassle of manually inspecting `mock.calls`. What do you think?